### PR TITLE
Plugin fallback for 2.X and 3.X version of phonegap

### DIFF
--- a/www/MapKit.js
+++ b/www/MapKit.js
@@ -34,8 +34,8 @@ function setDefaults(options) {
     };
 
     if (options) {
-        for(var i in defaults) 
-            if(typeof options[i] === "undefined") 
+        for(var i in defaults)
+            if(typeof options[i] === "undefined")
                 options[i] = defaults[i];
     }
 
@@ -67,4 +67,22 @@ MapKit.prototype = {
 
 };
 
-module.exports = new MapKit();
+
+if (cordovaRef && cordovaRef.addConstructor) {
+	cordovaRef.addConstructor(init);
+} else {
+	init();
+}
+
+function init () {
+	if(!window.plugins) {
+		window.plugins = {};
+	}
+	if(!window.plugins.mapKit) {
+		window.plugins.mapKit = new MapKit();
+	}
+}
+
+if (typeof module != 'undefined' && module.exports) {
+	module.exports = new MapKit();
+}


### PR DESCRIPTION
I have installed (`phonegap plugin add com.phonegap.plugins.mapkit`) your plugin with phonegap `3.4.0-0.19.7` and couldn't make it work properly. I have found a fix in the following link and integrated it in your code.
[Phonegap issue](https://github.com/phonegap-build/GAPlugin/pull/37)

Let me know what you think.
